### PR TITLE
13 update tag orders schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ published after last sent coub to chat.
 
 2) To subscribe to community or tag:    
 ```/subscribe community animals-pets weekly```    
-```/subscribe tag cars newest```
+```/subscribe tag cars popular```
 
 3) Bot will periodically send links to coubs for every subscription user has.    
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 ext {
-    set("PROJECT_VERSION", "0.3.0")
+    set("PROJECT_VERSION", "0.3.1")
 }
 
 //version = '0.0.1-SNAPSHOT'

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/controller/TagOrderController.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/controller/TagOrderController.java
@@ -1,6 +1,7 @@
 package ru.dankoy.subscriptionsholder.subscriptions_holder.core.controller;
 
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +16,7 @@ public class TagOrderController {
   private final OrderService orderService;
 
   @GetMapping(value = "/api/v1/tag_orders")
-  public List<OrderDTO> getAll() {
+  public @Valid List<OrderDTO> getAll() {
 
     var found = orderService.getAll();
 

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/domain/subscriptions/tag/Order.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/domain/subscriptions/tag/Order.java
@@ -30,4 +30,7 @@ public class Order {
   @Column(name = "name")
   private String name;
 
+  @Column(name = "value")
+  private String value;
+
 }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/tagsubscription/OrderCreateDTO.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/tagsubscription/OrderCreateDTO.java
@@ -1,5 +1,6 @@
 package ru.dankoy.subscriptionsholder.subscriptions_holder.core.dto.tagsubscription;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,12 +13,17 @@ import ru.dankoy.subscriptionsholder.subscriptions_holder.core.domain.subscripti
 @AllArgsConstructor
 public class OrderCreateDTO {
 
+  @NotEmpty
   private String name;
+
+  @NotEmpty
+  private String value;
 
   public static OrderCreateDTO toDTO(Order order) {
 
     return new OrderCreateDTO(
-        order.getName()
+        order.getName(),
+        order.getValue()
     );
 
   }
@@ -26,7 +32,8 @@ public class OrderCreateDTO {
 
     return new Order(
         0,
-        dto.getName()
+        dto.getName(),
+        dto.getValue()
     );
 
   }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/tagsubscription/OrderCreateDTO.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/tagsubscription/OrderCreateDTO.java
@@ -14,15 +14,11 @@ import ru.dankoy.subscriptionsholder.subscriptions_holder.core.domain.subscripti
 public class OrderCreateDTO {
 
   @NotEmpty
-  private String name;
-
-  @NotEmpty
   private String value;
 
   public static OrderCreateDTO toDTO(Order order) {
 
     return new OrderCreateDTO(
-        order.getName(),
         order.getValue()
     );
 
@@ -32,7 +28,7 @@ public class OrderCreateDTO {
 
     return new Order(
         0,
-        dto.getName(),
+        null,
         dto.getValue()
     );
 

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/tagsubscription/OrderDTO.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/tagsubscription/OrderDTO.java
@@ -1,5 +1,6 @@
 package ru.dankoy.subscriptionsholder.subscriptions_holder.core.dto.tagsubscription;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,13 +15,18 @@ public class OrderDTO {
 
   private long id;
 
+  @NotEmpty
   private String name;
+
+  @NotEmpty
+  private String value;
 
   public static OrderDTO toDTO(Order order) {
 
     return new OrderDTO(
         order.getId(),
-        order.getName()
+        order.getName(),
+        order.getValue()
     );
 
   }
@@ -29,7 +35,8 @@ public class OrderDTO {
 
     return new Order(
         dto.getId(),
-        dto.getName()
+        dto.getName(),
+        dto.getValue()
     );
 
   }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/repository/OrderRepository.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/repository/OrderRepository.java
@@ -7,5 +7,6 @@ import ru.dankoy.subscriptionsholder.subscriptions_holder.core.domain.subscripti
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
   Optional<Order> findByName(String name);
+  Optional<Order> findByValue(String value);
 
 }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/repository/TagSubRepository.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/repository/TagSubRepository.java
@@ -31,9 +31,9 @@ public interface TagSubRepository extends JpaRepository<TagSub, Long> {
 
 
   @EntityGraph(value = "tag-subscription-full-inherited", type = EntityGraphType.LOAD)
-  Optional<TagSub> getByChatChatIdAndTagTitleAndOrderName(
+  Optional<TagSub> getByChatChatIdAndTagTitleAndOrderValue(
       @Param("externalChatId") long externalChatId,
       @Param("tagTitle") String tagTitle,
-      @Param("orderName") String orderName);
+      @Param("orderValue") String orderValue);
 
 }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/service/OrderService.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/service/OrderService.java
@@ -7,5 +7,7 @@ public interface OrderService {
 
   Order getByName(String name);
 
+  Order getByValue(String value);
+
   List<Order> getAll();
 }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/service/OrderServiceImpl.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/service/OrderServiceImpl.java
@@ -24,6 +24,15 @@ public class OrderServiceImpl implements OrderService {
   }
 
   @Override
+  public Order getByValue(String value) {
+    var optional = orderRepository.findByValue(value);
+
+    return optional.orElseThrow(
+        () -> new ResourceNotFoundException(String.format("Tag order not found - %s", value))
+    );
+  }
+
+  @Override
   public List<Order> getAll() {
     return orderRepository.findAll();
   }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/service/TagSubServiceImpl.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/service/TagSubServiceImpl.java
@@ -37,10 +37,10 @@ public class TagSubServiceImpl implements TagSubService {
   public TagSub createSubscription(TagSub tagSubscription) {
 
     // check existence
-    var optional = tagSubRepository.getByChatChatIdAndTagTitleAndOrderName(
+    var optional = tagSubRepository.getByChatChatIdAndTagTitleAndOrderValue(
         tagSubscription.getChat().getChatId(),
         tagSubscription.getTag().getTitle(),
-        tagSubscription.getOrder().getName()
+        tagSubscription.getOrder().getValue()
     );
 
     // if exists throw exception
@@ -55,7 +55,7 @@ public class TagSubServiceImpl implements TagSubService {
     var tag = tagService.getByTitle(tagSubscription.getTag().getTitle());
     var scope = scopeService.getByName(tagSubscription.getScope().getName());
     var type = typeService.getByName(tagSubscription.getType().getName());
-    var order = orderService.getByName(tagSubscription.getOrder().getName());
+    var order = orderService.getByValue(tagSubscription.getOrder().getValue());
 
     // todo: do i even need to save chat when creating subscription?
 
@@ -102,10 +102,10 @@ public class TagSubServiceImpl implements TagSubService {
   @Override
   public void deleteSubscription(TagSub tagSubscription) {
 
-    var optional = tagSubRepository.getByChatChatIdAndTagTitleAndOrderName(
+    var optional = tagSubRepository.getByChatChatIdAndTagTitleAndOrderValue(
         tagSubscription.getChat().getChatId(),
         tagSubscription.getTag().getTitle(),
-        tagSubscription.getOrder().getName()
+        tagSubscription.getOrder().getValue()
     );
 
     optional.ifPresent(tagSubRepository::delete);
@@ -114,10 +114,10 @@ public class TagSubServiceImpl implements TagSubService {
 
   @Override
   public TagSub updatePermalink(TagSub tagSubscription) {
-    var optional = tagSubRepository.getByChatChatIdAndTagTitleAndOrderName(
+    var optional = tagSubRepository.getByChatChatIdAndTagTitleAndOrderValue(
         tagSubscription.getChat().getChatId(),
         tagSubscription.getTag().getTitle(),
-        tagSubscription.getOrder().getName()
+        tagSubscription.getOrder().getValue()
     );
 
     var found = optional.orElseThrow(

--- a/subscriptions_holder/src/main/resources/db/migration/4.0/V4.1__2024_02_02_update_tag_orders_schema.sql
+++ b/subscriptions_holder/src/main/resources/db/migration/4.0/V4.1__2024_02_02_update_tag_orders_schema.sql
@@ -1,37 +1,4 @@
 alter table tag_orders
     add value varchar(15);
 
-update
-    tag_orders
-set value = 'popular'
-where id =
-      (select id
-       from tag_orders
-       where tag_orders."name" = 'newest_popular');
-
-update
-    tag_orders
-set value = 'top'
-where id =
-      (select id
-       from tag_orders
-       where tag_orders."name" = 'likes_count');
-
-update
-    tag_orders
-set value = 'views_count'
-where id =
-      (select id
-       from tag_orders
-       where tag_orders."name" = 'views_count');
-
-update
-    tag_orders
-set value = 'fresh'
-where id =
-      (select id
-       from tag_orders
-       where tag_orders."name" = 'newest');
-
-
 

--- a/subscriptions_holder/src/main/resources/db/migration/4.0/V4.1__2024_02_02_update_tag_orders_schema.sql
+++ b/subscriptions_holder/src/main/resources/db/migration/4.0/V4.1__2024_02_02_update_tag_orders_schema.sql
@@ -1,0 +1,37 @@
+alter table tag_orders
+    add value varchar(15);
+
+update
+    tag_orders
+set value = 'popular'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'newest_popular');
+
+update
+    tag_orders
+set value = 'top'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'likes_count');
+
+update
+    tag_orders
+set value = 'views_count'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'views_count');
+
+update
+    tag_orders
+set value = 'fresh'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'newest');
+
+
+

--- a/subscriptions_holder/src/main/resources/db/migration/data/R__0007_add_values_to_tag_orders.sql
+++ b/subscriptions_holder/src/main/resources/db/migration/data/R__0007_add_values_to_tag_orders.sql
@@ -1,0 +1,31 @@
+update
+    tag_orders
+set value = 'popular'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'newest_popular');
+
+update
+    tag_orders
+set value = 'top'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'likes_count');
+
+update
+    tag_orders
+set value = 'views_count'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'views_count');
+
+update
+    tag_orders
+set value = 'fresh'
+where id =
+      (select id
+       from tag_orders
+       where tag_orders."name" = 'newest');

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/domain/tagsubscription/Order.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/domain/tagsubscription/Order.java
@@ -18,7 +18,9 @@ public class Order {
 
   private String name;
 
-  public Order(String name) {
-    this.name = name;
+  private String value;
+
+  public Order(String value) {
+    this.value = value;
   }
 }

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/bot/TelegramBotImpl.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/bot/TelegramBotImpl.java
@@ -340,25 +340,25 @@ public class TelegramBotImpl extends TelegramLongPollingBot implements TelegramB
     message.setChatId(inputMessage.getChat().getId());
 
     var tagName = command.get(COMMAND_FIRST_FIELD);
-    var orderName = command.get(COMMAND_SECOND_FIELD);
+    var orderValue = command.get(COMMAND_SECOND_FIELD);
 
     try {
 
       var s = tagSubscriptionService.subscribe(
           tagName,
-          orderName,
+          orderValue,
           "all",
           "",
           inputMessage.getChat().getId());
 
       message.setText(String.format("Subscribed to %s %s", s.getTag().getTitle(),
-          s.getOrder().getName()));
+          s.getOrder().getValue()));
       send(message);
 
     } catch (Conflict e) {
       message.setText(String.format("You are already subscribed to '%s - %s'",
           tagName,
-          orderName));
+          orderValue));
       send(message);
     } catch (NotFoundException e) {
       message.setText(e.getMessage());
@@ -376,18 +376,18 @@ public class TelegramBotImpl extends TelegramLongPollingBot implements TelegramB
     message.setChatId(inputMessage.getChat().getId());
 
     var tagName = command.get(COMMAND_FIRST_FIELD);
-    var orderName = command.get(COMMAND_SECOND_FIELD);
+    var orderValue = command.get(COMMAND_SECOND_FIELD);
 
     try {
 
       tagSubscriptionService.unsubscribe(
           tagName,
-          orderName,
+          orderValue,
           "all",
           "",
           inputMessage.getChat().getId());
 
-      message.setText(String.format("Unsubscribed from %s %s", tagName, orderName));
+      message.setText(String.format("Unsubscribed from %s %s", tagName, orderValue));
       send(message);
 
     } catch (Exception e) {
@@ -424,7 +424,7 @@ public class TelegramBotImpl extends TelegramLongPollingBot implements TelegramB
 
     // escape special chars in order names
     var updated = orders.stream()
-        .map(order -> new Order(escapeMetaCharacters(order.getName())))
+        .map(order -> new Order(escapeMetaCharacters(order.getValue())))
         .toList();
 
     Map<String, Object> templateData = new HashMap<>();

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/subscription/TagSubscriptionService.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/subscription/TagSubscriptionService.java
@@ -9,14 +9,14 @@ public interface TagSubscriptionService {
 
   TagSubscription subscribe(
       String tagName,
-      String orderName,
+      String orderValue,
       String scopeName,
       String typeName,
       long chatId);
 
   void unsubscribe(
       String tagName,
-      String orderName,
+      String orderValue,
       String scopeName,
       String typeName,
       long chatId

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/subscription/TagSubscriptionServiceImpl.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/subscription/TagSubscriptionServiceImpl.java
@@ -31,7 +31,7 @@ public class TagSubscriptionServiceImpl implements TagSubscriptionService {
   @Override
   public TagSubscription subscribe(
       String tagName,
-      String orderName,
+      String orderValue,
       String scopeName,
       String typeName,
       long chatId) {
@@ -45,7 +45,7 @@ public class TagSubscriptionServiceImpl implements TagSubscriptionService {
           0,
           tag,
           new Chat(chatId),
-          new Order(orderName),
+          new Order(orderValue),
           new Scope(scopeName),
           new Type(typeName),
           null,
@@ -68,7 +68,7 @@ public class TagSubscriptionServiceImpl implements TagSubscriptionService {
             0,
             new Tag(created.getTitle()),
             new Chat(chatId),
-            new Order(orderName),
+            new Order(orderValue),
             new Scope(scopeName),
             new Type(typeName),
             null,
@@ -90,7 +90,7 @@ public class TagSubscriptionServiceImpl implements TagSubscriptionService {
   @Override
   public void unsubscribe(
       String tagName,
-      String orderName,
+      String orderValue,
       String scopeName,
       String typeName,
       long chatId
@@ -100,7 +100,7 @@ public class TagSubscriptionServiceImpl implements TagSubscriptionService {
         0,
         new Tag(tagName),
         new Chat(chatId),
-        new Order(orderName),
+        new Order(orderValue),
         new Scope(scopeName),
         new Type(typeName),
         null,

--- a/telegram_bot/src/main/resources/freemarker/templates/subscriptions.ftl
+++ b/telegram_bot/src/main/resources/freemarker/templates/subscriptions.ftl
@@ -9,7 +9,7 @@
     <#if tagSubscriptions?has_content>
   Tag subscriptions
         <#list tagSubscriptions as tagSubscription>
-          ${tagSubscription?counter}: ${tagSubscription.tag.title} ${tagSubscription.order.name}
+          ${tagSubscription?counter}: ${tagSubscription.tag.title} ${tagSubscription.order.value}
         </#list>
     </#if>
 <#else>

--- a/telegram_bot/src/main/resources/freemarker/templates/tag_orders.ftl
+++ b/telegram_bot/src/main/resources/freemarker/templates/tag_orders.ftl
@@ -1,4 +1,4 @@
 Available tag orders:
 <#list orders as order>
-  *${order?counter}*: ${order.name}
+  *${order?counter}*: ${order.value}
 </#list>


### PR DESCRIPTION
# Description

Added value column for tag orders. This column is human readable version of name column, contains values similar to frontend of coub.com.
Updated subscriptions by tag controller and services, using value instead of name attribute. 
- Added migration for new schema
- Updated bot microservice

Fixes #13

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Create tag subscription with order value attribute
- [x] Delete tag subscription with order value attribute
- [x] Show all subscriptions returns values instead of order names
- [x] Command tag orders returns values instead of order names

**Test Configuration**:
* Firmware version: MacOS 14
* Hardware: M1 Pro
* SDK: jdk-17.0.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated project version if release is planned
