### PR TITLE
fix: order value is null in tag message

### DIFF
--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/core/domain/tagsubscription/Order.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/core/domain/tagsubscription/Order.java
@@ -1,6 +1,5 @@
 package ru.dankoy.kafkamessageconsumer.core.domain.tagsubscription;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -18,5 +17,4 @@ public class Order {
 
   private String name;
   private String value;
-
 }

--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/core/domain/tagsubscription/Order.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/core/domain/tagsubscription/Order.java
@@ -17,5 +17,6 @@ public class Order {
   private long id;
 
   private String name;
+  private String value;
 
 }

--- a/kafka_message_producer/src/main/java/ru/dankoy/kafkamessageproducer/core/domain/subscription/tagsubscription/Order.java
+++ b/kafka_message_producer/src/main/java/ru/dankoy/kafkamessageproducer/core/domain/subscription/tagsubscription/Order.java
@@ -1,6 +1,5 @@
 package ru.dankoy.kafkamessageproducer.core.domain.subscription.tagsubscription;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -17,5 +16,5 @@ public class Order {
   private long id;
 
   private String name;
-
+  private String value;
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/domain/subscribtionsholder/tagsubscription/Order.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/domain/subscribtionsholder/tagsubscription/Order.java
@@ -1,6 +1,5 @@
 package ru.dankoy.tcoubsinitiator.core.domain.subscribtionsholder.tagsubscription;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -18,5 +17,4 @@ public class Order {
 
   private String name;
   private String value;
-
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/domain/subscribtionsholder/tagsubscription/Order.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/domain/subscribtionsholder/tagsubscription/Order.java
@@ -17,5 +17,6 @@ public class Order {
   private long id;
 
   private String name;
+  private String value;
 
 }

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/bot/TelegramBotImpl.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/bot/TelegramBotImpl.java
@@ -585,7 +585,7 @@ public class TelegramBotImpl extends TelegramLongPollingBot implements TelegramB
 
     Map<String, Object> templateData = new HashMap<>();
     templateData.put("tagName", tagName);
-    templateData.put("orderName", orderValue);
+    templateData.put("orderValue", orderValue);
     templateData.put("url", coubUrl);
     var text = templateBuilder.writeTemplate(templateData, "tag_subscription_message.ftl");
 

--- a/telegram_bot/src/main/resources/freemarker/templates/tag_subscription_message.ftl
+++ b/telegram_bot/src/main/resources/freemarker/templates/tag_subscription_message.ftl
@@ -1,2 +1,2 @@
-tag #${tagName} #${orderName}
+tag #${tagName} #${orderValue}
 ${url}


### PR DESCRIPTION
# Description

Fix bug while sending message for tag subscription cause by order value is null in freemarker template. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test sending messages for tag subscription

**Test Configuration**:
* Firmware version: MacOS 14
* Hardware: Macbook M1 Pro
* SDK: jdk-21.0.2-tem

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
