### PR TITLE
fix: too many requests in filter and filter request only page 0

### DIFF
--- a/Dockerfile.coub_forwarder_telegram_bot
+++ b/Dockerfile.coub_forwarder_telegram_bot
@@ -21,7 +21,7 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+ENTRYPOINT java -Xms400m -Xmx400m \
              -XX:MaxMetaspaceSize=200m \
              -XX:NewSize=200m \
              -XX:MaxNewSize=200m \

--- a/Dockerfile.coub_smart_searcher
+++ b/Dockerfile.coub_smart_searcher
@@ -21,7 +21,7 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+ENTRYPOINT java -Xms400m -Xmx400m \
   -XX:MaxMetaspaceSize=200m \
   -XX:NewSize=200m \
   -XX:MaxNewSize=200m \

--- a/Dockerfile.kafka_message_consumer
+++ b/Dockerfile.kafka_message_consumer
@@ -21,7 +21,7 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+ENTRYPOINT java -Xms400m -Xmx400m \
              -XX:MaxMetaspaceSize=200m \
              -XX:NewSize=200m \
              -XX:MaxNewSize=200m \

--- a/Dockerfile.kafka_message_producer
+++ b/Dockerfile.kafka_message_producer
@@ -21,7 +21,7 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+ENTRYPOINT java -Xms400m -Xmx400m \
              -XX:MaxMetaspaceSize=200m \
              -XX:NewSize=200m \
              -XX:MaxNewSize=200m \

--- a/Dockerfile.spring_eureka_registry
+++ b/Dockerfile.spring_eureka_registry
@@ -21,7 +21,7 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+ENTRYPOINT java -Xms400m -Xmx400m \
              -XX:MaxMetaspaceSize=200m \
              -XX:NewSize=200m \
              -XX:MaxNewSize=200m \

--- a/Dockerfile.spring_gateway
+++ b/Dockerfile.spring_gateway
@@ -21,7 +21,7 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+ENTRYPOINT java -Xms400m -Xmx400m \
              -XX:MaxMetaspaceSize=200m \
              -XX:NewSize=200m \
              -XX:MaxNewSize=200m \

--- a/Dockerfile.subscriptions_holder
+++ b/Dockerfile.subscriptions_holder
@@ -32,7 +32,7 @@ RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 ENTRYPOINT java -Djasypt.encryptor.password=${JASYPT_PASSWORD} \
                 -Djasypt.encryptor.algorithm=PBEWithMD5AndDES \
                 -Djasypt.encryptor.ivGeneratorClassName=org.jasypt.iv.NoIvGenerator \
-                 -Xms700m -Xmx700m \
+                 -Xms400m -Xmx400m \
                   -XX:MaxMetaspaceSize=200m \
                   -XX:NewSize=200m \
                   -XX:MaxNewSize=200m \

--- a/Dockerfile.t_coubs_initiator
+++ b/Dockerfile.t_coubs_initiator
@@ -21,7 +21,10 @@ COPY ./settings.gradle ./
 
 RUN ["/bin/bash", "-c", "gradle clean bootJar -x test"]
 
-ENTRYPOINT java -Xms700m -Xmx700m \
+# remote debug
+# java -agentlib:jdwp=transport=dt_socket,server=y,address=*:8000,suspend=n
+
+ENTRYPOINT java -Xms400m -Xmx400m \
              -XX:MaxMetaspaceSize=200m \
              -XX:NewSize=200m \
              -XX:MaxNewSize=200m \

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    set("PROJECT_VERSION", "1.1.0")
+    set("PROJECT_VERSION", "1.1.1")
 }
 
 // doesn't work in build.gradle in buildSrc project

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/registry/SentCoubsRegistryServiceImpl.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/registry/SentCoubsRegistryServiceImpl.java
@@ -30,9 +30,10 @@ public class SentCoubsRegistryServiceImpl implements SentCoubsRegistryService {
     var totalPages = Integer.MAX_VALUE;
 
     var sort = Sort.by("id").ascending();
-    var pageable = PageRequest.of(currentPage, PER_PAGE, sort);
 
     while (currentPage <= totalPages) {
+
+      var pageable = PageRequest.of(currentPage, PER_PAGE, sort);
 
       Page<SentCoubsRegistry> page =
           sentCoubsRegisrtyFeign.getAllBySubscriptionIdAndDateAfter(

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/registry/SentCoubsRegistryServiceImpl.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/registry/SentCoubsRegistryServiceImpl.java
@@ -16,7 +16,7 @@ import ru.dankoy.tcoubsinitiator.core.feign.registry.SentCoubsRegisrtyFeign;
 public class SentCoubsRegistryServiceImpl implements SentCoubsRegistryService {
 
   private static final int FIRST_PAGE = 0;
-  private static final int PER_PAGE = 10;
+  private static final int PER_PAGE = 30;
 
   private final SentCoubsRegisrtyFeign sentCoubsRegisrtyFeign;
 

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceChannel.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceChannel.java
@@ -86,7 +86,7 @@ public class SchedulerSubscriptionServiceChannel {
 
       page++;
 
-      Utils.sleep(5_000);
+      Utils.sleep(3_000);
     }
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceCommunitySection.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceCommunitySection.java
@@ -89,7 +89,7 @@ public class SchedulerSubscriptionServiceCommunitySection {
 
       page++;
 
-      Utils.sleep(5_000);
+      Utils.sleep(3_000);
     }
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceTag.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceTag.java
@@ -83,7 +83,7 @@ public class SchedulerSubscriptionServiceTag {
 
       page++;
 
-      Utils.sleep(5_000);
+      Utils.sleep(3_000);
     }
   }
 }


### PR DESCRIPTION
# Description

- Fixed bug where filter by sent registry request only one (0) page multiple times.
- Increased per_page from 10 to 30. Should decrease amount of requests.
- Decreased wait timeout between subscription pages in scheduler.
- Decreased max memory from 700 to 400 for every docker container. 

Fixes #84 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test filter by registry. Requests should be with correct page number.


**Test Configuration**:

* Firmware version: MacOS 14.3 (23D56)
* Hardware: Apple M1 Pro
* SDK: Eclipse Temurin JDK 21.0.2+13-LTS


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated project version if release is planned
