### PR TITLE
feat: Increase kafka message consuming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    set("PROJECT_VERSION", "1.3.0")
+    set("PROJECT_VERSION", "1.3.2")
 }
 
 // doesn't work in build.gradle in buildSrc project

--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConfig.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConfig.java
@@ -93,7 +93,7 @@ public class KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConf
     //        "ru.dankoy.kafkamessageproducer.core.domain.message"); // from producer
 
     // max amount of messages got by one poll
-    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 3);
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10);
 
     // polling interval. how many seconds consumer can work with pack of messages
     props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 20_000);


### PR DESCRIPTION
# Description

Since resilence in bot service do rate limiting when sending after release #109. Initiator can send much more messages to kafka. It doesn't need hard limit on 3 messages. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
