### PR TITLE
fix: added check when locale is null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    set("PROJECT_VERSION", "1.3.2")
+    set("PROJECT_VERSION", "1.3.3")
 }
 
 // doesn't work in build.gradle in buildSrc project

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/localeprovider/LocaleProviderImpl.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/localeprovider/LocaleProviderImpl.java
@@ -1,19 +1,37 @@
 package ru.dankoy.telegrambot.core.service.localeprovider;
 
 import java.util.Locale;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.objects.Message;
+import ru.dankoy.telegrambot.config.bot.properties.LocaleConfig;
 
 @Service
+@RequiredArgsConstructor
 public class LocaleProviderImpl implements LocaleProvider {
+
+  private final LocaleConfig localeConfig;
 
   @Override
   public Locale getLocale(Message message) {
-    return Locale.forLanguageTag(message.getFrom().getLanguageCode());
+
+    var langCode = message.getFrom().getLanguageCode();
+
+    if (Objects.isNull(langCode)) {
+      return localeConfig.getDefaultLocale();
+    } else {
+      return Locale.of(langCode);
+    }
   }
 
   @Override
   public Locale getLocale(String locale) {
-    return Locale.forLanguageTag(locale);
+
+    if (Objects.isNull(locale)) {
+      return localeConfig.getDefaultLocale();
+    } else {
+      return Locale.of(locale);
+    }
   }
 }

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/localeprovider/LocaleProviderImpl.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/localeprovider/LocaleProviderImpl.java
@@ -18,16 +18,16 @@ public class LocaleProviderImpl implements LocaleProvider {
 
     var langCode = message.getFrom().getLanguageCode();
 
-    if (Objects.isNull(langCode)) {
-      return localeConfig.getDefaultLocale();
-    } else {
-      return Locale.of(langCode);
-    }
+    return checkAndReturn(langCode);
   }
 
   @Override
   public Locale getLocale(String locale) {
 
+    return checkAndReturn(locale);
+  }
+
+  private Locale checkAndReturn(String locale) {
     if (Objects.isNull(locale)) {
       return localeConfig.getDefaultLocale();
     } else {


### PR DESCRIPTION
# Description

Added check in LocaleProvider if it is null. If null, return default locale. If not get by language code from user.

Fixes #120 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated project version if release is planned
