### PR TITLE
refactor: exclude eureka requests from zipkin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    set("PROJECT_VERSION", "1.3.3")
+    set("PROJECT_VERSION", "1.3.4")
 }
 
 // doesn't work in build.gradle in buildSrc project

--- a/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/config/ObservabilityConfig.java
+++ b/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/config/ObservabilityConfig.java
@@ -7,6 +7,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -22,7 +23,7 @@ public class ObservabilityConfig {
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipActuatorEndpointsFromObservation() {
     PathMatcher pathMatcher = new AntPathMatcher("/");
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate(
@@ -38,9 +39,25 @@ public class ObservabilityConfig {
 
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipSecuritySpansFromObservation() {
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
+  }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    // this excludes output requests from service made by some rest client.
+    return registry ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ClientRequestObservationContext serverContext) {
+                    return !serverContext.getCarrier().getURI().getPath().startsWith("/eureka");
+                  } else {
+                    return true;
+                  }
+                });
   }
 }

--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/ObservabilityConfig.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/ObservabilityConfig.java
@@ -7,6 +7,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -22,7 +23,7 @@ public class ObservabilityConfig {
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipActuatorEndpointsFromObservation() {
     PathMatcher pathMatcher = new AntPathMatcher("/");
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate(
@@ -38,9 +39,25 @@ public class ObservabilityConfig {
 
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipSecuritySpansFromObservation() {
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
+  }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    // this excludes output requests from service made by some rest client.
+    return registry ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ClientRequestObservationContext serverContext) {
+                    return !serverContext.getCarrier().getURI().getPath().startsWith("/eureka");
+                  } else {
+                    return true;
+                  }
+                });
   }
 }

--- a/kafka_message_producer/src/main/java/ru/dankoy/kafkamessageproducer/config/ObservabilityConfig.java
+++ b/kafka_message_producer/src/main/java/ru/dankoy/kafkamessageproducer/config/ObservabilityConfig.java
@@ -7,6 +7,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -22,7 +23,7 @@ public class ObservabilityConfig {
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipActuatorEndpointsFromObservation() {
     PathMatcher pathMatcher = new AntPathMatcher("/");
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate(
@@ -38,9 +39,25 @@ public class ObservabilityConfig {
 
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipSecuritySpansFromObservation() {
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
+  }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    // this excludes output requests from service made by some rest client.
+    return registry ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ClientRequestObservationContext serverContext) {
+                    return !serverContext.getCarrier().getURI().getPath().startsWith("/eureka");
+                  } else {
+                    return true;
+                  }
+                });
   }
 }

--- a/spring_gateway/src/main/java/ru/dankoy/spring_gateway/config/ObservabilityConfig.java
+++ b/spring_gateway/src/main/java/ru/dankoy/spring_gateway/config/ObservabilityConfig.java
@@ -4,6 +4,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.server.reactive.observation.ServerRequestObservationContext;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -36,5 +37,21 @@ public class ObservabilityConfig {
         registry
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
+  }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    // this excludes output requests from service made by some rest client.
+    return registry ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ClientRequestObservationContext serverContext) {
+                    return !serverContext.getCarrier().getURI().getPath().startsWith("/eureka");
+                  } else {
+                    return true;
+                  }
+                });
   }
 }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/config/ObservabilityConfig.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/config/ObservabilityConfig.java
@@ -4,6 +4,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -14,7 +15,7 @@ public class ObservabilityConfig {
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipActuatorEndpointsFromObservation() {
     PathMatcher pathMatcher = new AntPathMatcher("/");
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate(
@@ -30,9 +31,25 @@ public class ObservabilityConfig {
 
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipSecuritySpansFromObservation() {
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
+  }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    // this excludes output requests from service made by some rest client.
+    return registry ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ClientRequestObservationContext serverContext) {
+                    return !serverContext.getCarrier().getURI().getPath().startsWith("/eureka");
+                  } else {
+                    return true;
+                  }
+                });
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/config/ObservabilityConfig.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/config/ObservabilityConfig.java
@@ -7,6 +7,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -22,7 +23,7 @@ public class ObservabilityConfig {
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipActuatorEndpointsFromObservation() {
     PathMatcher pathMatcher = new AntPathMatcher("/");
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate(
@@ -38,9 +39,25 @@ public class ObservabilityConfig {
 
   @Bean
   ObservationRegistryCustomizer<ObservationRegistry> skipSecuritySpansFromObservation() {
-    return (registry) ->
+    return registry ->
         registry
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
+  }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    // this excludes output requests from service made by some rest client.
+    return registry ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ClientRequestObservationContext serverContext) {
+                    return !serverContext.getCarrier().getURI().getPath().startsWith("/eureka");
+                  } else {
+                    return true;
+                  }
+                });
   }
 }

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/config/ObservabilityConfig.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/config/ObservabilityConfig.java
@@ -43,4 +43,21 @@ public class ObservabilityConfig {
             .observationConfig()
             .observationPredicate((name, context) -> !name.startsWith("spring.security"));
   }
+
+  @Bean
+  ObservationRegistryCustomizer<ObservationRegistry> skipEurekaRegistrySpansFromObservation() {
+    PathMatcher pathMatcher = new AntPathMatcher("/");
+    return (registry) ->
+        registry
+            .observationConfig()
+            .observationPredicate(
+                (name, context) -> {
+                  if (context instanceof ServerRequestObservationContext observationContext) {
+                    return !pathMatcher.match(
+                        "/eureka/**", observationContext.getCarrier().getRequestURI());
+                  } else {
+                    return true;
+                  }
+                });
+  }
 }


### PR DESCRIPTION
# Description

Added `ObservationRegistryCustomizer<ObservationRegistry>` to exclude eureka requests from zipkin tracing.

More on fix [here](https://stackoverflow.com/questions/75143863/how-to-exclude-some-uri-to-be-observed-using-springboot3-micrometer)

Outgoing requests filtered in different observation registry. More on that [here](https://docs.spring.io/spring-framework/reference/integration/observability.html)

Also [here](https://github.com/spring-projects/spring-boot/issues/34400)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Build and run with updated configs. Check zipkin for eureka requests. None should appear.


**Test Configuration**:
* Firmware version: MacOS Sonoma 14.5 (23F79)
* Hardware: Apple M1 Pro
* SDK: JDK 21.0.3-tem

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated project version if release is planned
