### PR TITLE
fix: integration flow is sync for messages from kafka

### DIFF
--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/config/integration/FlowSyncConfig.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/config/integration/FlowSyncConfig.java
@@ -1,0 +1,120 @@
+package ru.dankoy.telegrambot.config.integration;
+
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.handler.advice.RateLimiterRequestHandlerAdvice;
+import org.springframework.messaging.MessageChannel;
+import ru.dankoy.telegrambot.core.domain.message.ChannelSubscriptionMessage;
+import ru.dankoy.telegrambot.core.domain.message.CommunitySubscriptionMessage;
+import ru.dankoy.telegrambot.core.domain.message.CoubMessage;
+import ru.dankoy.telegrambot.core.domain.message.TagSubscriptionMessage;
+import ru.dankoy.telegrambot.core.service.bot.TelegramBot;
+import ru.dankoy.telegrambot.core.service.reply.ReplyCreatorService;
+
+/**
+ * @author dankoy
+ *     <p>Should work in sync mode. It was made to fix bug <a
+ *     href="https://github.com/Dankoy/jforwarder/issues/126">...</a>
+ */
+@Slf4j
+@Configuration
+public class FlowSyncConfig {
+
+  @Bean
+  public MessageChannel subscriptionMessagesChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel sendMessageDirectChannel() {
+    // this channel send messages as soon they created.
+    //  With queue integration flow waited 5 seconds every time before handle message.
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel communitySubscriptionSendDirectChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel tagSubscriptionSendDirectChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel channelSubscriptionSendDirectChannel() {
+    return new DirectChannel();
+  }
+
+  // rate limiter for one message in 2 second
+  @Bean
+  public RateLimiterRequestHandlerAdvice rateLimiterRequestOneInTwoSecondsHandlerAdvice() {
+    return new RateLimiterRequestHandlerAdvice(
+        RateLimiterConfig.custom()
+            .limitRefreshPeriod(Duration.ofSeconds(2))
+            .limitForPeriod(1)
+            .build());
+  }
+
+  @Bean
+  public IntegrationFlow sendMessageSyncFlow(TelegramBot telegramBot) {
+    return IntegrationFlow.from(sendMessageDirectChannel())
+        .handle(
+            telegramBot,
+            "sendMessage",
+            c -> c.advice(rateLimiterRequestOneInTwoSecondsHandlerAdvice()))
+        .get();
+  }
+
+  @Bean
+  public IntegrationFlow subscriptionMessagesFlow() {
+
+    return IntegrationFlow.from(subscriptionMessagesChannel())
+        .<CoubMessage, Class<?>>route(
+            CoubMessage::getClass,
+            m ->
+                m.channelMapping(
+                        CommunitySubscriptionMessage.class,
+                        "communitySubscriptionSendDirectChannel")
+                    .channelMapping(
+                        TagSubscriptionMessage.class, "tagSubscriptionSendDirectChannel")
+                    .channelMapping(
+                        ChannelSubscriptionMessage.class, "channelSubscriptionSendDirectChannel"))
+        .get();
+  }
+
+  @Bean
+  public IntegrationFlow communitySubscriptionSendMessageFlow(
+      ReplyCreatorService replyCreatorService) {
+
+    return IntegrationFlow.from(communitySubscriptionSendDirectChannel())
+        .handle(replyCreatorService, "createCommunitySubscriptionMessage")
+        .channel(sendMessageDirectChannel())
+        .get();
+  }
+
+  @Bean
+  public IntegrationFlow tagSubscriptionSendMessageFlow(ReplyCreatorService replyCreatorService) {
+
+    return IntegrationFlow.from(tagSubscriptionSendDirectChannel())
+        .handle(replyCreatorService, "createTagSubscriptionMessage")
+        .channel(sendMessageDirectChannel())
+        .get();
+  }
+
+  @Bean
+  public IntegrationFlow channelSubscriptionSendMessageFlow(
+      ReplyCreatorService replyCreatorService) {
+
+    return IntegrationFlow.from(channelSubscriptionSendDirectChannel())
+        .handle(replyCreatorService, "createChannelSubscriptionMessage")
+        .channel(sendMessageDirectChannel())
+        .get();
+  }
+}

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/controller/SubscriptionController.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/controller/SubscriptionController.java
@@ -7,26 +7,26 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.dankoy.telegrambot.core.domain.message.ChannelSubscriptionMessage;
 import ru.dankoy.telegrambot.core.domain.message.CommunitySubscriptionMessage;
 import ru.dankoy.telegrambot.core.domain.message.TagSubscriptionMessage;
-import ru.dankoy.telegrambot.core.gateway.BotMessageGateway;
+import ru.dankoy.telegrambot.core.gateway.BotMessageSyncGateway;
 
 @RequiredArgsConstructor
 @RestController
 public class SubscriptionController {
 
-  private final BotMessageGateway botMessageGateway;
+  private final BotMessageSyncGateway botMessageSyncGateway;
 
   @PostMapping("/api/v1/community_message")
   public void sendMessage(@RequestBody CommunitySubscriptionMessage message) {
-    botMessageGateway.process(message);
+    botMessageSyncGateway.process(message);
   }
 
   @PostMapping("/api/v1/tag_message")
   public void sendMessage(@RequestBody TagSubscriptionMessage message) {
-    botMessageGateway.process(message);
+    botMessageSyncGateway.process(message);
   }
 
   @PostMapping("/api/v1/channel_message")
   public void sendMessage(@RequestBody ChannelSubscriptionMessage message) {
-    botMessageGateway.process(message);
+    botMessageSyncGateway.process(message);
   }
 }

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/exceptions/BotSendMessageException.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/exceptions/BotSendMessageException.java
@@ -1,0 +1,12 @@
+package ru.dankoy.telegrambot.core.exceptions;
+
+public class BotSendMessageException extends BotException {
+
+  public BotSendMessageException(String message) {
+    super(message);
+  }
+
+  public BotSendMessageException(String message, Exception e) {
+    super(message, e);
+  }
+}

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/gateway/BotMessageGateway.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/gateway/BotMessageGateway.java
@@ -3,14 +3,10 @@ package ru.dankoy.telegrambot.core.gateway;
 import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.telegram.telegrambots.meta.api.objects.Message;
-import ru.dankoy.telegrambot.core.domain.message.CoubMessage;
 
 @MessagingGateway(errorChannel = "errorChannel")
 public interface BotMessageGateway {
 
   @Gateway(requestChannel = "inputMessageChannel")
   void process(Message telegramMessage);
-
-  @Gateway(requestChannel = "subscriptionMessagesChannel")
-  void process(CoubMessage communitySubscriptionMessage);
 }

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/gateway/BotMessageSyncGateway.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/gateway/BotMessageSyncGateway.java
@@ -1,0 +1,15 @@
+package ru.dankoy.telegrambot.core.gateway;
+
+import org.springframework.integration.annotation.Gateway;
+import org.springframework.integration.annotation.MessagingGateway;
+import ru.dankoy.telegrambot.core.domain.message.CoubMessage;
+
+// To make sync gateway all their channels must be sync (direct channel), not executors, also don't
+// include errorChannel name here
+
+@MessagingGateway
+public interface BotMessageSyncGateway {
+
+  @Gateway(requestChannel = "subscriptionMessagesChannel")
+  void process(CoubMessage communitySubscriptionMessage);
+}

--- a/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/bot/TelegramBotIntegrationFlowImpl.java
+++ b/telegram_bot/src/main/java/ru/dankoy/telegrambot/core/service/bot/TelegramBotIntegrationFlowImpl.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import ru.dankoy.telegrambot.config.bot.configuration.botflow.BotConfiguration;
 import ru.dankoy.telegrambot.core.exceptions.BotException;
+import ru.dankoy.telegrambot.core.exceptions.BotSendMessageException;
 import ru.dankoy.telegrambot.core.gateway.BotMessageGateway;
 import ru.dankoy.telegrambot.core.service.chat.TelegramChatService;
 
@@ -149,9 +150,11 @@ public class TelegramBotIntegrationFlowImpl extends TelegramLongPollingBot imple
       } else {
         // some other exception in api
         log.error("Something went wrong: {}", e.getMessage());
+        throw new BotSendMessageException(e.getMessage(), e);
       }
     } catch (TelegramApiException e) {
       log.error("Error sending message - {}", e.getMessage());
+      throw new BotSendMessageException(e.getMessage(), e);
     }
   }
 }


### PR DESCRIPTION
# Description

Added new synchronous integration flow for sending messages from kafka for subscriptions. If telegram api failed then exception is thrown and controller reply with error message 500. So kafka never acknowledge failed messages and should send them later again.

These changes doesn't affect work flow with input messages from chats. They still work in async flow mode.

Fixes #126 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test sending messages from kafka. Should get 500 error in case of any exception in sync flow.

Test Configuration:
Firmware version: MacOS 14.3 (23D56)
Hardware: Apple M1 Pro
SDK: Eclipse Temurin JDK 21.0.2+13-LTS

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
