### PR TITLE
refactor: added feign timeouts and changed consumer intervals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    set("PROJECT_VERSION", "1.3.8")
+    set("PROJECT_VERSION", "1.3.9")
 }
 
 // doesn't work in build.gradle in buildSrc project

--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConfig.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConfig.java
@@ -96,7 +96,8 @@ public class KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConf
     props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 3);
 
     // polling interval. how many seconds consumer can work with pack of messages
-    // time to process last polled records + idle between polls must be less than max.poll.interval.ms.
+    // time to process last polled records + idle between polls must be less than
+    // max.poll.interval.ms.
     props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 60_000);
 
     // before he hits new poll
@@ -148,7 +149,8 @@ public class KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConf
     factory.setCommonErrorHandler(errorHandler());
 
     // idlebeetweenpolls - in pair with maxPollInterval make time between two polls
-    // somehow these settings make (idleBetweenPolls=30_000 and maxPollInterval=20_000) consumer consume messages every 15 seconds
+    // somehow these settings make (idleBetweenPolls=30_000 and maxPollInterval=20_000) consumer
+    // consume messages every 15 seconds
 
     factory.getContainerProperties().setListenerTaskExecutor(concurrentTaskExecutor());
     return factory;

--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConfig.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConfig.java
@@ -96,7 +96,8 @@ public class KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConf
     props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 3);
 
     // polling interval. how many seconds consumer can work with pack of messages
-    props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 20_000);
+    // time to process last polled records + idle between polls must be less than max.poll.interval.ms.
+    props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 60_000);
 
     // before he hits new poll
     props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 500);
@@ -138,7 +139,7 @@ public class KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConf
 
     // if you have one consumer but two topics or partitions, then set to two, etc.
     factory.setConcurrency(2);
-    factory.getContainerProperties().setIdleBetweenPolls(30_000); // polling interval
+    factory.getContainerProperties().setIdleBetweenPolls(5_000); // polling interval
     factory
         .getContainerProperties()
         .setPollTimeout(1_000); // wait in kafka for messages if queue is empty
@@ -147,7 +148,7 @@ public class KafkaBatchWithOneContainerFactoryForTwoListenersAndRecordFilterConf
     factory.setCommonErrorHandler(errorHandler());
 
     // idlebeetweenpolls - in pair with maxPollInterval make time between two polls
-    // somehow these settings make consumer consume messages every 15 seconds
+    // somehow these settings make (idleBetweenPolls=30_000 and maxPollInterval=20_000) consumer consume messages every 15 seconds
 
     factory.getContainerProperties().setListenerTaskExecutor(concurrentTaskExecutor());
     return factory;

--- a/kafka_message_consumer/src/main/resources/application.yml
+++ b/kafka_message_consumer/src/main/resources/application.yml
@@ -31,7 +31,12 @@ spring:
     listener:
       ack-mode: batch
 
-
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 10000
 
 server:
   port: 8085


### PR DESCRIPTION
# Description

Added feign timeouts. That is necessary to not wait too long for message to be sent by bot.

Increased max message poll interval in kafka consumer.

Overrides #111

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test start and produce consume messages to/from kafka.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated project version if release is planned
