### PR TITLE
feat: ratelimiter for coub requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Open coub channel in browser. Find the last word in URL. Use it.
 13. Zipkin
 14. Docker compose
 15. Telegrambots
+16. Resilience4j
 
 ## Monitoring stack
 

--- a/buildSrc/src/main/groovy/spring-resilience4j-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring-resilience4j-conventions.gradle
@@ -1,0 +1,12 @@
+// share spring boot and dependency management for other projects via plugin
+
+dependencies {
+
+    // resilence4j
+    implementation "io.github.resilience4j:resilience4j-spring-boot3"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "org.springframework.boot:spring-boot-starter-aop"
+
+}
+
+

--- a/buildSrc/src/main/groovy/spring-resilience4j-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring-resilience4j-conventions.gradle
@@ -4,7 +4,6 @@ dependencies {
 
     // resilence4j
     implementation "io.github.resilience4j:resilience4j-spring-boot3"
-    implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-aop"
 
 }

--- a/coub_smart_searcher/build.gradle
+++ b/coub_smart_searcher/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'spring-feign-conventions'
     id 'micrometer-conventions'
     id 'loki-conventions'
+    id 'spring-resilience4j-conventions'
 }
 
 group = 'ru.dankoy.coubsmartsearcher'

--- a/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/feign/CoubSearchFeign.java
+++ b/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/feign/CoubSearchFeign.java
@@ -1,11 +1,13 @@
 package ru.dankoy.coubtagssearcher.core.feign;
 
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import ru.dankoy.coubtagssearcher.core.domain.coubcom.ChannelsWrapper;
 
+@RateLimiter(name = "coub")
 @Cacheable(cacheNames = "coubs-feign-cache", cacheManager = "caffeineCacheManager")
 @FeignClient(name = "coub-search", url = "${coub.connector.gatewayApiUrl}api/v2/search")
 public interface CoubSearchFeign {

--- a/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/feign/CoubSmartSearchFeign.java
+++ b/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/feign/CoubSmartSearchFeign.java
@@ -1,11 +1,13 @@
 package ru.dankoy.coubtagssearcher.core.feign;
 
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import ru.dankoy.coubtagssearcher.core.domain.coubcom.TagsWrapper;
 
+@RateLimiter(name = "coub")
 @Cacheable(cacheNames = "coubs-feign-cache", cacheManager = "caffeineCacheManager")
 @FeignClient(name = "coubs", url = "${coub.connector.gatewayApiUrl}api/v2/smart_search/")
 public interface CoubSmartSearchFeign {

--- a/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/service/channel/ChannelServiceImpl.java
+++ b/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/service/channel/ChannelServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import ru.dankoy.coubtagssearcher.core.domain.Channel;
 import ru.dankoy.coubtagssearcher.core.exceptions.ResourceNotFoundException;
 import ru.dankoy.coubtagssearcher.core.feign.CoubSearchFeign;
-import ru.dankoy.coubtagssearcher.core.service.Utils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -41,7 +40,6 @@ public class ChannelServiceImpl implements ChannelService {
 
         log.info("On page '{}' channel '{}' not found", page, permalink);
         page++;
-        Utils.sleep(3_000);
 
       } else {
         var foundChannel = optionalFoundChannel.get();

--- a/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/service/tag/TagServiceImpl.java
+++ b/coub_smart_searcher/src/main/java/ru/dankoy/coubtagssearcher/core/service/tag/TagServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import ru.dankoy.coubtagssearcher.core.domain.Tag;
 import ru.dankoy.coubtagssearcher.core.exceptions.ResourceNotFoundException;
 import ru.dankoy.coubtagssearcher.core.feign.CoubSmartSearchFeign;
-import ru.dankoy.coubtagssearcher.core.service.Utils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,7 +31,6 @@ public class TagServiceImpl implements TagService {
       if (optionalFoundTag.isEmpty()) {
         log.info("On page '{}' tag '{}' not found", page, title);
         page++;
-        Utils.sleep(3_000);
 
         wrapper = coubSmartSearchFeign.getTags(title, page);
       } else {

--- a/coub_smart_searcher/src/main/resources/application.yml
+++ b/coub_smart_searcher/src/main/resources/application.yml
@@ -17,10 +17,10 @@ server:
 resilience4j.ratelimiter:
   instances:
     coub:
-      # one request in two seconds
+      # one request in one second
       limitForPeriod: 1
-      limitRefreshPeriod: 2s
-      timeoutDuration: 1s
+      limitRefreshPeriod: 1s
+      timeoutDuration: 1s # must be equals or more than limitRefreshPeriod or you get RequestNotPermitted
       registerHealthIndicator: true
 
 eureka:

--- a/coub_smart_searcher/src/main/resources/application.yml
+++ b/coub_smart_searcher/src/main/resources/application.yml
@@ -14,6 +14,14 @@ server:
     include-exception: false
   port: 8086
 
+resilience4j.ratelimiter:
+  instances:
+    coub:
+      # one request in two seconds
+      limitForPeriod: 1
+      limitRefreshPeriod: 2s
+      timeoutDuration: 1s
+      registerHealthIndicator: true
 
 eureka:
   client:

--- a/t_coubs_initiator/build.gradle
+++ b/t_coubs_initiator/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'micrometer-conventions'
     id 'loki-conventions'
     id 'spring-cache-conventions'
+    id 'spring-resilience4j-conventions'
 }
 
 group = 'ru.dankoy.tcoubsinitiator'

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/feign/coub/CoubFeign.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/feign/coub/CoubFeign.java
@@ -1,5 +1,6 @@
 package ru.dankoy.tcoubsinitiator.core.feign.coub;
 
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import ru.dankoy.tcoubsinitiator.core.domain.coubcom.coub.CoubWrapper;
 // GET
 //    https://coub.com/api/v2/timeline/community/anime/rising?page=1
 
+@RateLimiter(name = "coub")
 @Cacheable(cacheNames = "coubs-feign-cache", cacheManager = "caffeineCacheManager")
 @FeignClient(name = "coubs", url = "${coub.connector.gatewayApiUrl}api/v2/")
 public interface CoubFeign {

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/coubfinder/CoubFinderServiceImpl.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/coubfinder/CoubFinderServiceImpl.java
@@ -77,8 +77,6 @@ public class CoubFinderServiceImpl implements CoubFinderService {
         log.info("Coub with last permalink '{}' not found", lastPermalink);
         log.info("Trying page: {}", page);
 
-        sleep(3_000);
-
         wrapper =
             coubService.getCoubsWrapperForCommunityAndSection(
                 communitySubscription.getCommunity().getName(),
@@ -149,8 +147,6 @@ public class CoubFinderServiceImpl implements CoubFinderService {
         log.info("Coub with last permalink '{}' not found", lastPermalink);
         log.info("Trying page: {}", page);
 
-        sleep(5_000);
-
         wrapper =
             coubService.getCoubsWrapperForTag(
                 tagSubscription.getTag().getTitle(),
@@ -192,15 +188,5 @@ public class CoubFinderServiceImpl implements CoubFinderService {
   private List<Coub> limitCoubs(List<Coub> coubs, int limit) {
     coubs.sort((coub1, coub2) -> coub2.getPublishedAt().compareTo(coub1.getPublishedAt()));
     return coubs.subList(0, limit);
-  }
-
-  private void sleep(long millis) {
-
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while trying to get coubs", e);
-    }
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/coubfinder/CoubFinderServiceWithoutSorting.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/coubfinder/CoubFinderServiceWithoutSorting.java
@@ -78,8 +78,6 @@ public class CoubFinderServiceWithoutSorting implements CoubFinderService {
         log.info("Coub with last permalink '{}' not found", lastPermalink);
         log.info("Trying page: {}", page);
 
-        sleep(3_000);
-
         wrapper =
             coubService.getCoubsWrapperForCommunityAndSection(
                 communitySubscription.getCommunity().getName(),
@@ -148,8 +146,6 @@ public class CoubFinderServiceWithoutSorting implements CoubFinderService {
 
         log.info("Coub with last permalink '{}' not found", lastPermalink);
         log.info("Trying page: {}", page);
-
-        sleep(5_000);
 
         wrapper =
             coubService.getCoubsWrapperForTag(
@@ -223,8 +219,6 @@ public class CoubFinderServiceWithoutSorting implements CoubFinderService {
         log.info("Coub with last permalink '{}' not found", lastPermalink);
         log.info("Trying page: {}", page);
 
-        sleep(5_000);
-
       } else {
 
         log.info("Found coub with lastPermalink in current list");
@@ -254,16 +248,6 @@ public class CoubFinderServiceWithoutSorting implements CoubFinderService {
       return coubs.subList(0, limit);
     } else {
       return coubs.subList(0, coubs.size());
-    }
-  }
-
-  private void sleep(long millis) {
-
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while trying to get coubs", e);
     }
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceChannel.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceChannel.java
@@ -14,7 +14,6 @@ import ru.dankoy.tcoubsinitiator.core.service.channelsubscription.ChannelSubscri
 import ru.dankoy.tcoubsinitiator.core.service.coubfinder.CoubFinderService;
 import ru.dankoy.tcoubsinitiator.core.service.filter.FilterByRegistryService;
 import ru.dankoy.tcoubsinitiator.core.service.messageproducerconnectorservice.MessageProducerChannelSubscriptionService;
-import ru.dankoy.tcoubsinitiator.core.service.utils.Utils;
 
 /**
  * @deprecated in favor for @{link SchedulerChannelSubscriptionService.class}
@@ -88,8 +87,6 @@ public class SchedulerSubscriptionServiceChannel {
           allSubscriptionsWithActiveChats.getContent().size());
 
       page++;
-
-      Utils.sleep(3_000);
     }
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceCommunitySection.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceCommunitySection.java
@@ -16,7 +16,6 @@ import ru.dankoy.tcoubsinitiator.core.service.coubfinder.CoubFinderService;
 import ru.dankoy.tcoubsinitiator.core.service.filter.FilterByRegistryService;
 import ru.dankoy.tcoubsinitiator.core.service.messageproducerconnectorservice.MessageProducerCommunitySubscriptionService;
 import ru.dankoy.tcoubsinitiator.core.service.subscription.SubscriptionService;
-import ru.dankoy.tcoubsinitiator.core.service.utils.Utils;
 
 /**
  * @deprecated in favor for @{link SchedulerCommunitySubscriptionService.class}
@@ -91,8 +90,6 @@ public class SchedulerSubscriptionServiceCommunitySection {
           communitySubscriptionsPage.getContent().size());
 
       page++;
-
-      Utils.sleep(3_000);
     }
   }
 }

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceTag.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/service/sheduler/SchedulerSubscriptionServiceTag.java
@@ -14,7 +14,6 @@ import ru.dankoy.tcoubsinitiator.core.service.coubfinder.CoubFinderService;
 import ru.dankoy.tcoubsinitiator.core.service.filter.FilterByRegistryService;
 import ru.dankoy.tcoubsinitiator.core.service.messageproducerconnectorservice.MessageProducerTagSubscriptionService;
 import ru.dankoy.tcoubsinitiator.core.service.tagsubscription.TagSubscriptionService;
-import ru.dankoy.tcoubsinitiator.core.service.utils.Utils;
 
 /**
  * @deprecated in favor for @{link SchedulerTagSubscriptionService.class}
@@ -85,8 +84,6 @@ public class SchedulerSubscriptionServiceTag {
           "Amount of tag subscriptions processed: {}", tagSubscriptionsPage.getContent().size());
 
       page++;
-
-      Utils.sleep(3_000);
     }
   }
 }

--- a/t_coubs_initiator/src/main/resources/application.yml
+++ b/t_coubs_initiator/src/main/resources/application.yml
@@ -22,6 +22,14 @@ coub:
     filter:
       days: 30
 
+resilience4j.ratelimiter:
+  instances:
+    coub:
+      # one request in two seconds
+      limitForPeriod: 1
+      limitRefreshPeriod: 2s
+      timeoutDuration: 1s
+      registerHealthIndicator: true
 
 logging:
   level:

--- a/t_coubs_initiator/src/main/resources/application.yml
+++ b/t_coubs_initiator/src/main/resources/application.yml
@@ -25,10 +25,10 @@ coub:
 resilience4j.ratelimiter:
   instances:
     coub:
-      # one request in two seconds
+      # one request in one second
       limitForPeriod: 1
-      limitRefreshPeriod: 2s
-      timeoutDuration: 1s
+      limitRefreshPeriod: 1s
+      timeoutDuration: 1s # must be equals or more than limitRefreshPeriod or you get RequestNotPermitted
       registerHealthIndicator: true
 
 logging:


### PR DESCRIPTION
# Description

Added ratelimiter for coub api requests 1 request in 1 second. It is used instead of `Thread.sleep()` in for-each. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run t-coub-initiator. No errors should be seen. Requests rate is 1 req/s
- [x] Run coub-smart-searcher. No errors should be seen. Requests rate is 1 req/s

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
