### PR TITLE
refactor: removed subscription from fetching for registry

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -23,10 +23,17 @@ jobs:
       id: filter
       with:
         filters: |
-          subscriptions_holder: subscriptions_holder/src
-          t_coubs_initiator: t_coubs_initiator/src
-          coub_smart_searcher: coub_smart_searcher/src
-          kafka_message_producer: kafka_message_producer/src
-          kafka_message_consumer: kafka_message_consumer/src
-          telegram_bot: telegram_bot/src
-          subscriptions_scheduler: subscriptions_scheduler/src
+          subscriptions_holder: 
+            - 'subscriptions_holder/src/**'
+          t_coubs_initiator: 
+            - 't_coubs_initiator/src/**'
+          coub_smart_searcher: 
+            - 'coub_smart_searcher/src/**'
+          kafka_message_producer: 
+            - 'kafka_message_producer/src/**'
+          kafka_message_consumer: 
+            - 'kafka_message_consumer/src/**'
+          telegram_bot: 
+            - 'telegram_bot/src/**'
+          subscriptions_scheduler: 
+            - 'subscriptions_scheduler/src/**'

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/domain/registry/SentCoubsRegistry.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/domain/registry/SentCoubsRegistry.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedSubgraph;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -19,10 +20,13 @@ import ru.dankoy.subscriptionsholder.subscriptions_holder.core.domain.subscripti
 @NamedEntityGraph(
     name = "sent-coubs-registry-full",
     includeAllAttributes = true,
-    attributeNodes = {
-      @NamedAttributeNode("subscription"),
-      @NamedAttributeNode("coubPermalink"),
-      @NamedAttributeNode("dateTime")
+    attributeNodes = {@NamedAttributeNode("subscription")})
+@NamedEntityGraph(
+    name = "sent-coubs-registry-with-partial-subscription",
+    subgraphs = {
+      @NamedSubgraph(
+          name = "subgraph.partial-subscription",
+          attributeNodes = {@NamedAttributeNode("id")})
     })
 @Table(name = "sent_coubs_registry")
 @Entity

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/sentcoubsregistry/SentCoubsRegistryDTO.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/dto/sentcoubsregistry/SentCoubsRegistryDTO.java
@@ -24,8 +24,6 @@ public class SentCoubsRegistryDTO {
   @NotNull
   private long id;
 
-  @Valid @NotNull private SubscriptionDTO subscription;
-
   @Valid @NotNull @NotEmpty private String coubPermalink;
 
   @Valid @NotNull private LocalDateTime dateTime;
@@ -34,18 +32,8 @@ public class SentCoubsRegistryDTO {
 
     return SentCoubsRegistryDTO.builder()
         .id(sentCoubsRegistry.getId())
-        .subscription(SubscriptionDTO.toDTO(sentCoubsRegistry.getSubscription()))
         .coubPermalink(sentCoubsRegistry.getCoubPermalink())
         .dateTime(sentCoubsRegistry.getDateTime())
         .build();
-  }
-
-  public static SentCoubsRegistry fromDTO(SentCoubsRegistryDTO dto) {
-
-    return new SentCoubsRegistry(
-        dto.getId(),
-        SubscriptionDTO.fromDTO(dto.getSubscription()),
-        dto.getCoubPermalink(),
-        dto.getDateTime());
   }
 }

--- a/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/repository/SentCoubsRegistryRepository.java
+++ b/subscriptions_holder/src/main/java/ru/dankoy/subscriptionsholder/subscriptions_holder/core/repository/SentCoubsRegistryRepository.java
@@ -19,7 +19,9 @@ public interface SentCoubsRegistryRepository extends JpaRepository<SentCoubsRegi
   Page<SentCoubsRegistry> getAllBySubscriptionId(
       @Param("subscriptionId") long subscriptionId, Pageable pageable);
 
-  @EntityGraph(value = "sent-coubs-registry-full", type = EntityGraphType.LOAD)
+  @EntityGraph(
+      value = "sent-coubs-registry-with-partial-subscription",
+      type = EntityGraphType.FETCH)
   Page<SentCoubsRegistry> getAllBySubscriptionIdAndDateTimeAfter(
       @Param("subscriptionId") long subscriptionId,
       @Param("dateTime") LocalDateTime dateTime,

--- a/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/domain/subscribtionsholder/registry/SentCoubsRegistry.java
+++ b/t_coubs_initiator/src/main/java/ru/dankoy/tcoubsinitiator/core/domain/subscribtionsholder/registry/SentCoubsRegistry.java
@@ -6,7 +6,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import ru.dankoy.tcoubsinitiator.core.domain.subscribtionsholder.subscription.Subscription;
 
 @EqualsAndHashCode
 @Getter
@@ -16,8 +15,6 @@ import ru.dankoy.tcoubsinitiator.core.domain.subscribtionsholder.subscription.Su
 public class SentCoubsRegistry {
 
   private long id;
-
-  private Subscription subscription;
 
   private String coubPermalink;
 


### PR DESCRIPTION
# Description

Excluded Subscription object from sql request when sent coubs registry is accessed. That transformed action from multiple requests to db into single one.

`select scr1_0.id,scr1_0.coub_permalink,scr1_0.date_time,scr1_0.subscription_id from sent_coubs_registry scr1_0 left join subscriptions s1_0 on s1_0.id=scr1_0.subscription_id where s1_0.id=? and scr1_0.date_time>? fetch first ? rows only`

Fixes #167 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test sent coub registry requests and see that it works faster and only using one request.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
