### PR TITLE
Fix unaccessibel group chats

### DIFF
--- a/telegram_chat_service/src/main/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooq.java
+++ b/telegram_chat_service/src/main/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooq.java
@@ -137,13 +137,19 @@ public class TelegramChatDaoJooq implements TelegramChatDao {
   @Override
   public Optional<ChatDTO> findByChatIdAndMessageThreadId(long chatId, Integer threadId) {
 
-    var condition = noCondition();
-    condition =
-        condition
+    var conditionLeft = noCondition();
+    var conditionRight = noCondition();
+
+    conditionLeft =
+        conditionLeft.and(CHATS.CHAT_ID.eq(chatId)).and(CHATS.MESSAGE_THREAD_ID.eq(threadId));
+
+    conditionRight =
+        conditionRight
             .and(CHATS.CHAT_ID.eq(chatId))
-            .and(CHATS.MESSAGE_THREAD_ID.eq(threadId))
-            .or(CHATS.MESSAGE_THREAD_ID.isNull())
-            .and(CHATS.CHAT_ID.eq(chatId));
+            .and(CHATS.MESSAGE_THREAD_ID.isNull())
+            .and(val(threadId).isNull());
+
+    var condition = or(conditionLeft, conditionRight);
 
     ChatsRecord chatsRecord = dsl.fetchOne(CHATS, condition);
 
@@ -155,13 +161,19 @@ public class TelegramChatDaoJooq implements TelegramChatDao {
   @Override
   public Optional<ChatDTO> findForUpdateByChatIdAndMessageThreadId(long chatId, Integer threadId) {
 
-    var condition = noCondition();
-    condition =
-        condition
+    var conditionLeft = noCondition();
+    var conditionRight = noCondition();
+
+    conditionLeft =
+        conditionLeft.and(CHATS.CHAT_ID.eq(chatId)).and(CHATS.MESSAGE_THREAD_ID.eq(threadId));
+
+    conditionRight =
+        conditionRight
             .and(CHATS.CHAT_ID.eq(chatId))
-            .and(CHATS.MESSAGE_THREAD_ID.eq(threadId))
-            .or(CHATS.MESSAGE_THREAD_ID.isNull())
-            .and(CHATS.CHAT_ID.eq(chatId));
+            .and(CHATS.MESSAGE_THREAD_ID.isNull())
+            .and(val(threadId).isNull());
+
+    var condition = or(conditionLeft, conditionRight);
 
     Optional<Record> chatsRecord =
         dsl.select().from(CHATS).where(condition).forUpdate().wait(3).fetchOptional();

--- a/telegram_chat_service/src/main/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooq.java
+++ b/telegram_chat_service/src/main/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooq.java
@@ -138,7 +138,12 @@ public class TelegramChatDaoJooq implements TelegramChatDao {
   public Optional<ChatDTO> findByChatIdAndMessageThreadId(long chatId, Integer threadId) {
 
     var condition = noCondition();
-    condition = condition.and(CHATS.CHAT_ID.eq(chatId)).and(CHATS.MESSAGE_THREAD_ID.eq(threadId));
+    condition =
+        condition
+            .and(CHATS.CHAT_ID.eq(chatId))
+            .and(CHATS.MESSAGE_THREAD_ID.eq(threadId))
+            .or(CHATS.MESSAGE_THREAD_ID.isNull())
+            .and(CHATS.CHAT_ID.eq(chatId));
 
     ChatsRecord chatsRecord = dsl.fetchOne(CHATS, condition);
 
@@ -151,7 +156,12 @@ public class TelegramChatDaoJooq implements TelegramChatDao {
   public Optional<ChatDTO> findForUpdateByChatIdAndMessageThreadId(long chatId, Integer threadId) {
 
     var condition = noCondition();
-    condition = condition.and(CHATS.CHAT_ID.eq(chatId)).and(CHATS.MESSAGE_THREAD_ID.eq(threadId));
+    condition =
+        condition
+            .and(CHATS.CHAT_ID.eq(chatId))
+            .and(CHATS.MESSAGE_THREAD_ID.eq(threadId))
+            .or(CHATS.MESSAGE_THREAD_ID.isNull())
+            .and(CHATS.CHAT_ID.eq(chatId));
 
     Optional<Record> chatsRecord =
         dsl.select().from(CHATS).where(condition).forUpdate().wait(3).fetchOptional();

--- a/telegram_chat_service/src/main/java/ru/dankoy/telegramchatservice/core/service/TelegramChatServiceJooq.java
+++ b/telegram_chat_service/src/main/java/ru/dankoy/telegramchatservice/core/service/TelegramChatServiceJooq.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ru.dankoy.telegramchatservice.core.component.uuidgenerator.UUIDGenerator;
 import ru.dankoy.telegramchatservice.core.domain.dto.ChatDTO;
 import ru.dankoy.telegramchatservice.core.domain.dto.ChatWithSubs;
@@ -45,12 +46,14 @@ public class TelegramChatServiceJooq implements TelegramChatService {
   }
 
   @Override
+  @Transactional
   public List<ChatDTO> saveAll(List<ChatDTO> chats) {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'saveAll'");
   }
 
   @Override
+  @Transactional
   public ChatDTO save(ChatDTO chat) {
 
     chat.setId(uuidgenerator.randomUUID());
@@ -59,6 +62,7 @@ public class TelegramChatServiceJooq implements TelegramChatService {
   }
 
   @Override
+  @Transactional
   public ChatDTO update(ChatDTO chat) {
     // get the existing chat by id
 
@@ -77,6 +81,7 @@ public class TelegramChatServiceJooq implements TelegramChatService {
   }
 
   @Override
+  @Transactional
   public void deleteChats(List<ChatDTO> chats) {
     dao.deleteBatch(chats);
   }

--- a/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooqTest.java
+++ b/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooqTest.java
@@ -65,6 +65,9 @@ class TelegramChatDaoJooqTest extends TestContainerBase implements ChatMaker {
 
     var actual = telegramChatDao.findByChatId(chat.getChatId());
 
+    System.out.println(chat);
+    System.out.println(actual);
+
     assertThat(actual.get()).isNotNull().isEqualTo(chat);
   }
 
@@ -91,6 +94,9 @@ class TelegramChatDaoJooqTest extends TestContainerBase implements ChatMaker {
 
     var actual =
         telegramChatDao.findByChatIdAndMessageThreadId(chat.getChatId(), chat.getMessageThreadId());
+
+    System.out.println(chat);
+    System.out.println(actual);
 
     assertThat(actual.get()).isNotNull().isEqualTo(chat);
   }

--- a/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooqTest.java
+++ b/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/repository/TelegramChatDaoJooqTest.java
@@ -65,9 +65,6 @@ class TelegramChatDaoJooqTest extends TestContainerBase implements ChatMaker {
 
     var actual = telegramChatDao.findByChatId(chat.getChatId());
 
-    System.out.println(chat);
-    System.out.println(actual);
-
     assertThat(actual.get()).isNotNull().isEqualTo(chat);
   }
 
@@ -94,9 +91,6 @@ class TelegramChatDaoJooqTest extends TestContainerBase implements ChatMaker {
 
     var actual =
         telegramChatDao.findByChatIdAndMessageThreadId(chat.getChatId(), chat.getMessageThreadId());
-
-    System.out.println(chat);
-    System.out.println(actual);
 
     assertThat(actual.get()).isNotNull().isEqualTo(chat);
   }

--- a/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/service/ChatMaker.java
+++ b/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/service/ChatMaker.java
@@ -1,6 +1,7 @@
 package ru.dankoy.telegramchatservice.core.service;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import ru.dankoy.telegramchatservice.core.domain.Chat;
 import ru.dankoy.telegramchatservice.core.domain.dto.ChatDTO;
@@ -8,15 +9,19 @@ import ru.dankoy.telegramchatservice.core.domain.dto.ChatDTO;
 public interface ChatMaker {
 
   default Chat makeChat(long chatId) {
-    var date = LocalDateTime.now();
-
+    DateTimeFormatter formatter =
+    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS");
+    var date = LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter);
+    
     return new Chat(
         0L, chatId, "type", "title", "firstName", "lastName", "username", true, 1, date, date);
   }
 
   default ChatDTO makeChat(UUID id, long chatId) {
-    var date = LocalDateTime.now();
-
+    DateTimeFormatter formatter =
+    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS");
+    var date = LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter);
+    
     return new ChatDTO(
         id, chatId, "type", "title", "firstName", "lastName", "username", true, 1, date, date);
   }

--- a/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/service/ChatMaker.java
+++ b/telegram_chat_service/src/test/java/ru/dankoy/telegramchatservice/core/service/ChatMaker.java
@@ -9,19 +9,17 @@ import ru.dankoy.telegramchatservice.core.domain.dto.ChatDTO;
 public interface ChatMaker {
 
   default Chat makeChat(long chatId) {
-    DateTimeFormatter formatter =
-    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS");
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS");
     var date = LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter);
-    
+
     return new Chat(
         0L, chatId, "type", "title", "firstName", "lastName", "username", true, 1, date, date);
   }
 
   default ChatDTO makeChat(UUID id, long chatId) {
-    DateTimeFormatter formatter =
-    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS");
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS");
     var date = LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter);
-    
+
     return new ChatDTO(
         id, chatId, "type", "title", "firstName", "lastName", "username", true, 1, date, date);
   }

--- a/telegram_chat_service/src/test/resources/application.yml
+++ b/telegram_chat_service/src/test/resources/application.yml
@@ -22,5 +22,9 @@ server:
 logging:
   level:
     root: INFO
+    org:
+      jooq:
+        tools:
+          LoggerListener: TRACE
   pattern:
     level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"


### PR DESCRIPTION
# Description

Fixed problem after DDD apply when group chats with messageThreadId = null is not accessible anymore. 

Fixes #190 

Also added transactional annotation to jooq service methods.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test get chat by id and message thread id. Should work with and without message thread id.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
