### PR TITLE
Update health check for telegram chat service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -531,7 +531,7 @@ services:
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
     healthcheck:
-      test: [ "CMD-SHELL", "curl localhost:8082/actuator" ]
+      test: [ "CMD-SHELL", "curl localhost:8088/actuator" ]
       interval: 5s
       timeout: 2s
       retries: 10


### PR DESCRIPTION
# Description

docker shows unhelthy status for telegram-chat-service 

`telegram-chat-service               /__cacert_entrypoint.sh /b ...   Up (unhealthy)`

Updated health checks in docker-compose to fix it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- It was not

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
