### PR TITLE
chore: added zipkin datasource and link from trace to logs

### DIFF
--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -16,19 +16,18 @@ services:
      networks:
        - jforwarder-network
 
-  #  tempo:
-  #    image: grafana/tempo
-  #    container_name: grafana-tempo
-  #    command: [ "-config.file=/etc/tempo.yaml" ]
-  #    volumes:
-  #      - ./tempo/tempo-local.yml:/etc/tempo.yaml
-  #      - tempo_volume:/tmp/tempo
-  #    ports:
-  #      - "14268"  # jaeger ingest
-  #      - "9411:9411" # zipkin
-  #    networks:
-  #      - jforwarder-network
-  #
+  # tempo:
+  #   image: grafana/tempo:main-17e20a4
+  #   container_name: grafana-tempo
+  #   command: [ "-config.file=/etc/tempo.yml" ]
+  #   volumes:
+  #     - ./tempo/tempo-local.yml:/etc/tempo.yml:ro
+  #     - tempo_volume:/tmp/tempo
+  #   ports:
+  #     - "3200:3200"
+  #   networks:
+  #     - jforwarder-network
+
   loki:
     image: grafana/loki:3.2.0
     container_name: grafana-loki

--- a/monitoring/grafana/provisioning/datasources/Datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/Datasource.yml
@@ -39,23 +39,42 @@ datasources:
       httpHeaderValue1: "jforwarder"
     version: 1                            # well, versioning
 
-#  - id: Tempo
-#    name: Tempo
-#    type: tempo
-#    access: proxy
-#    orgId: 1
-#    url: http://grafana-tempo:3200
-#    basicAuth: false
-#    isDefault: false
-#    version: 1
-#    editable: false
-#    apiVersion: 1
-#    uid: tempo
-#    jsonData:
-#      httpMethod: GET
-#      tracesToLogs:
-#        datasourceUid: 'loki'
-#
+  # - id: Tempo
+  #   name: Tempo
+  #   type: tempo
+  #   access: proxy
+  #   orgId: 1
+  #   url: http://grafana-tempo:3200
+  #   basicAuth: false
+  #   isDefault: false
+  #   version: 1
+  #   editable: false
+  #   apiVersion: 1
+  #   uid: tempo
+  #   jsonData:
+  #     httpMethod: GET
+  #     tracesToLogsV2:
+  #       datasourceUid: 'loki'
+  #       spanStartTimeShift: '-1h'
+  #       spanEndTimeShift: '1h'
+  #       filterByTraceID: true
+  #       filterBySpanID: true
+  #     tracesToMetrics:
+  #       datasourceUid: Prometheus
+  #     tracesToLogs:
+  #       datasourceUid: loki
+  #       mapTagNamesEnabled: true
+  #       filterByTraceID: true
+  #       filterBySpanID: true
+  #       spanStartTimeShift: '-10m'
+  #       spanEndTimeShift: '10m'
+  #     lokiSearch:
+  #       datasourceUid: loki
+  #     serviceMap:
+  #       datasourceUid: Prometheus
+  #     nodeGraph:
+  #       enabled: true
+
   - id: Loki
     name: Loki
     type: loki

--- a/monitoring/grafana/provisioning/datasources/Datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/Datasource.yml
@@ -3,6 +3,10 @@ apiVersion: 1
 deleteDatasources:
   - name: Prometheus
     orgId: 1
+  - name: Loki
+    orgId: 1
+  - name: Zipkin
+    orgId: 1
 
 datasources:
 
@@ -64,9 +68,62 @@ datasources:
     version: 1
     editable: false
     apiVersion: 1
-#    jsonData:
-#      derivedFields:
-#        - datasourceUid: tempo
-#          matcherRegex: \[.+,(.+?),
-#          name: traceID
-#          url: $${__value.raw}
+    # Doesn't work. Correct regex should be provided
+    # jsonData:
+    #   maxLines: 1000
+    #   derivedFields:
+    #     # Field with internal link pointing to data source in Grafana.
+    #     # datasourceUid value can be anything, but it should be unique across all defined data source uids.
+    #     - datasourceUid: zipkin
+    #       matcherRegex: "traceID=(\\w+)"
+    #       name: TraceID
+    #       # url will be interpreted as query for the datasource
+    #       url: '$${__value.raw}'
+    #       # optional for URL Label to set a custom display label for the link.
+    #       urlDisplayLabel: 'View Trace'
+
+    #     # Field with external link.
+    #     - matcherRegex: "traceID=(\\w+)"
+    #       name: TraceID_External
+    #       url: 'http://localhost:9411/zipkin/traces/$${__value.raw}'
+
+  - id: Zipkin
+    uid: zipkin
+    type: zipkin
+    name: Zipkin
+    editable: false                        # whether it should be editable
+    isDefault: false                      # whether this should be the default DS
+    org_id: 1                             # id of the organization to tie this datasource to
+    access: proxy
+    url: "http://zipkin:9411/"
+    basicAuth: false
+    readOnly: true
+    jsonData:
+      tracesToLogsV2:
+        # Field with an internal link pointing to a logs data source in Grafana.
+        # datasourceUid value must match the uid value of the logs data source.
+        datasourceUid: 'loki'
+        spanStartTimeShift: '-1h'
+        spanEndTimeShift: '1h'
+        tags: ['job', 'instance', 'pod', 'namespace']
+        filterByTraceID: false
+        filterBySpanID: true
+        customQuery: true
+        query: '{traceID="$${__span.traceId}"} |= "$${__span.spanId}"'
+      tracesToMetrics:
+        datasourceUid: 'prometheus'
+        spanStartTimeShift: '-1h'
+        spanEndTimeShift: '1h'
+        tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
+        queries:
+          - name: 'Sample query'
+            query: 'sum(rate(traces_spanmetrics_latency_bucket{$$__tags}[5m]))'
+      nodeGraph:
+        enabled: true
+      traceQuery:
+        timeShiftEnabled: true
+        spanStartTimeShift: '-1h'
+        spanEndTimeShift: '1h'
+      spanBar:
+        type: 'None'
+    version: 1                            # well, versioning

--- a/monitoring/grafana/provisioning/datasources/Datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/Datasource.yml
@@ -68,24 +68,19 @@ datasources:
     version: 1
     editable: false
     apiVersion: 1
-    # Doesn't work. Correct regex should be provided
-    # jsonData:
-    #   maxLines: 1000
-    #   derivedFields:
-    #     # Field with internal link pointing to data source in Grafana.
-    #     # datasourceUid value can be anything, but it should be unique across all defined data source uids.
-    #     - datasourceUid: zipkin
-    #       matcherRegex: "traceID=(\\w+)"
-    #       name: TraceID
-    #       # url will be interpreted as query for the datasource
-    #       url: '$${__value.raw}'
-    #       # optional for URL Label to set a custom display label for the link.
-    #       urlDisplayLabel: 'View Trace'
-
-    #     # Field with external link.
-    #     - matcherRegex: "traceID=(\\w+)"
-    #       name: TraceID_External
-    #       url: 'http://localhost:9411/zipkin/traces/$${__value.raw}'
+    jsonData:
+        maxLines: 1000
+        derivedFields:
+          # Field with internal link pointing to data source in Grafana.
+          # datasourceUid value can be anything, but it should be unique across all defined data source uids.
+          - datasourceUid: zipkin
+            matcherRegex: '.+ --- \[.+\] \[.+\] \[(\w*)-\w*\] .+'
+            name: TraceID
+            url: $${__value.raw}
+          # Field with external link.
+          - matcherRegex: '.+ --- \[.+\] \[.+\] \[(\w*)-\w*\] .+'
+            name: TraceID_External
+            url: 'http://localhost:9411/zipkin/traces/$${__value.raw}'  
 
   - id: Zipkin
     uid: zipkin
@@ -103,8 +98,8 @@ datasources:
         # Field with an internal link pointing to a logs data source in Grafana.
         # datasourceUid value must match the uid value of the logs data source.
         datasourceUid: 'loki'
-        spanStartTimeShift: '-1h'
-        spanEndTimeShift: '1h'
+        spanStartTimeShift: '-30m'
+        spanEndTimeShift: '30m'
         tags: ['job', 'instance', 'pod', 'namespace']
         filterByTraceID: false
         filterBySpanID: true
@@ -112,8 +107,8 @@ datasources:
         query: '{traceID="$${__span.traceId}"} |= "$${__span.spanId}"'
       tracesToMetrics:
         datasourceUid: 'prometheus'
-        spanStartTimeShift: '-1h'
-        spanEndTimeShift: '1h'
+        spanStartTimeShift: '-30m'
+        spanEndTimeShift: '30m'
         tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
         queries:
           - name: 'Sample query'


### PR DESCRIPTION
# Description

Added zipkin datasource to grafana and added link from trace to logs.

From logs view user can jump to trace in external zipkin or internal grafana zipkin datasource and back from trace view to logs.

Fixes #211 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run project. Zipkin traces should be explored and jumping into logs from traces should work.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
