### PR TITLE
fix: schema-registry metrics couldn't be pushed to mimir

### DIFF
--- a/monitoring/mimir/mimir.yml
+++ b/monitoring/mimir/mimir.yml
@@ -35,6 +35,7 @@ ingester:
 limits:
   # Delete from storage metrics data older than 1 year.
   compactor_blocks_retention_period: 1y
+  max_label_names_per_series: 60
 
 usage_stats:
   enabled: false


### PR DESCRIPTION
# Description

Prometheus couldn't push metrics from schema-registry container to mimir because container contains too much labels.

Increased labels limit from 30 to 60.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run project. See shcme-registry metrics in cadvisor dashboard.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
