### PR TITLE
refactor: comply loki url to 1.8.1 release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -101,6 +101,7 @@ services:
       - SCHEMA_REGISTRY=http://schema-registry:8081
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -134,6 +135,7 @@ services:
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
       - KAFKA_SERVER=http://kafka:9092
       - SCHEMA_REGISTRY=http://schema-registry:8081
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -183,6 +185,7 @@ services:
         -Xlog:gc=info:file=./gc-%p-%t.log:tags,uptime,time,level:filecount=5,filesize=10m
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
     healthcheck:
       test: [ "CMD-SHELL", "curl localhost:8082/actuator" ]
       interval: 5s
@@ -234,6 +237,7 @@ services:
         -XX:MaxNewSize=150m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError
         -XX:HeapDumpPath=./dump.hprof -XX:+UseGCOverheadLimit -XX:+UseStringDeduplication
         -Xlog:gc=info:file=./gc-%p-%t.log:tags,uptime,time,level:filecount=5,filesize=10m
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
     networks:
       - jforwarder-network
     healthcheck:
@@ -266,6 +270,7 @@ services:
     environment:
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms250m -Xmx250m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -307,6 +312,7 @@ services:
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
       - GATEWAY_COUB_URL=http://spring-gateway:8760/cc/
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -339,6 +345,7 @@ services:
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
       - TELEGRAM_BOT_NAME=${TELEGRAM_BOT_NAME}
       - TELEGRAM_BOT_API_TOKEN=${TELEGRAM_BOT_API_TOKEN}
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -372,6 +379,7 @@ services:
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
       - GATEWAY_COUB_URL=http://spring-gateway:8760/cc/
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -404,6 +412,7 @@ services:
     environment:
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
       - |
         JVM_PARAMS=
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=150m -XX:NewSize=150m 
@@ -474,6 +483,7 @@ services:
         -Xlog:gc=info:file=./gc-%p-%t.log:tags,uptime,time,level:filecount=5,filesize=10m
       - EUREKA_SERVER=http://spring-eureka-registry:8761/eureka
       - ZIPKIN_SERVER=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
     healthcheck:
       test: [ "CMD-SHELL", "curl localhost:8088/actuator" ]
       interval: 5s


### PR DESCRIPTION
# Description

Added loki url env variable for services in docker-compose to comply to 1.8.1 release changes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] It was not


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
