### PR TITLE
fix: added memory to subscriptions-holder deployment

### DIFF
--- a/kuber/project/deployments/templates/subscriptions-holder-deployment.template
+++ b/kuber/project/deployments/templates/subscriptions-holder-deployment.template
@@ -33,5 +33,5 @@ spec:
               memory: 256Mi
             limits:
               cpu: 300m
-              memory: 512Mi
+              memory: 600Mi
               


### PR DESCRIPTION
# Description

Subscriptions holder pod restarts constantly. Seems like OOM issue. Increased memory to 600Mi.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
