### PR TITLE
Increase memory limit to 550 for telegram-chat-service-deployment

### DIFF
--- a/kuber/project/deployments/templates/telegram-chat-service-deployment.template
+++ b/kuber/project/deployments/templates/telegram-chat-service-deployment.template
@@ -33,5 +33,5 @@ spec:
               memory: 256Mi
             limits:
               cpu: 300m
-              memory: 550Mi
+              memory: 600Mi
               

--- a/kuber/project/deployments/templates/telegram-chat-service-deployment.template
+++ b/kuber/project/deployments/templates/telegram-chat-service-deployment.template
@@ -33,5 +33,5 @@ spec:
               memory: 256Mi
             limits:
               cpu: 300m
-              memory: 512Mi
+              memory: 550Mi
               


### PR DESCRIPTION
# Description

Pod crashes with oom. Increased memory from 512 to 600.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated project version if release is planned
