### PR TITLE
fix: minio tenant values region is broken

### DIFF
--- a/kuber/monitoring/minio/tenant-values.yaml
+++ b/kuber/monitoring/minio/tenant-values.yaml
@@ -56,25 +56,18 @@ tenant:
   buckets: 
   - name: mimir-blocks
     objectLock: false        # optional
-    region: null       # optional
   - name: mimir-ruler
     objectLock: false        # optional
-    region: null      # optional
   - name: mimir-storage
     objectLock: false        # optional
-    region: null       # optional
   - name: mimir
     objectLock: false
-    region: null
   - name: loki-chunks
     objectLock: false        # optional
-    region: null       # optional
   - name: loki-ruler
     objectLock: false        # optional
-    region: null       # optional
   - name: loki-admin
     objectLock: false        # optional
-    region: null       # optional 
 
   ###
   # Array of Kubernetes secrets from which the Operator generates MinIO users during tenant provisioning.


### PR DESCRIPTION
Error

```shell
Error: INSTALLATION FAILED: Tenant.minio.min.io "minio" is invalid: [spec.buckets[0].region: Invalid value: "null": spec.buckets[0].region in body must be of type string: "null", spec.buckets[1].region: Invalid value: "null": spec.buckets[1].region in body must be of type string: "null", spec.buckets[2].region: Invalid value: "null": spec.buckets[2].region in body must be of type string: "null", spec.buckets[3].region: Invalid value: "null": spec.buckets[3].region in body must be of type string: "null", spec.buckets[4].region: Invalid value: "null": spec.buckets[4].region in body must be of type string: "null", spec.buckets[5].region: Invalid value: "null": spec.buckets[5].region in body must be of type string: "null", spec.buckets[6].region: Invalid value: "null": spec.buckets[6].region in body must be of type string: "null", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```

Fix of minio bucket region values