### PR TITLE
fix(kafka-consumer): increased max poll interval

### DIFF
--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaNotBatchProtobufConfig.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaNotBatchProtobufConfig.java
@@ -238,7 +238,7 @@ public class KafkaNotBatchProtobufConfig {
     KafkaErrorHandler errorHandler =
         new KafkaErrorHandler(
             (consumerRecord, e) -> {
-              // logic to execute when all the retry attemps are exhausted
+              // logic to execute when all the retry attempts are exhausted
             },
             fixedBackOff);
     errorHandler.addRetryableExceptions(SocketTimeoutException.class);

--- a/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaNotBatchProtobufConfig.java
+++ b/kafka_message_consumer/src/main/java/ru/dankoy/kafkamessageconsumer/config/kafka/KafkaNotBatchProtobufConfig.java
@@ -82,7 +82,7 @@ public class KafkaNotBatchProtobufConfig {
     // polling interval. how many seconds consumer can work with pack of messages
     // time to process last polled records + idle between polls must be less than
     // max.poll.interval.ms.
-    props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 15_000);
+    props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 40_000);
 
     // before he hits new poll
     props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 500);


### PR DESCRIPTION
ncreased max poll interval to fix #306 to 40s

Since there are 3 retries and telegram rest client is timed out in 10 seconds the overall time is spend for one message is 30 seconds.