### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
   prometheus-postgres-exporter-subscriptions-holder:
     env_file:
     - ".env"
-    image: "bitnami/postgres-exporter:0.17.1"
+    image: "soldevelo/postgres-exporter:0.17.1"
     container_name: "prometheus-postgres-exporter-subscriptions-holder"
     ports:
     - "9187:9187"
@@ -107,7 +107,7 @@ services:
   prometheus-postgres-exporter-telegram-chat:
     env_file:
     - ".env"
-    image: "bitnami/postgres-exporter:0.17.1"
+    image: "soldevelo/postgres-exporter:0.17.1"
     container_name: "prometheus-postgres-exporter-telegram-chat"
     ports:
     - "9188:9187"


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/postgres-exporter:0.17.1` → [`soldevelo/postgres-exporter:0.17.1`](https://hub.docker.com/r/soldevelo/postgres-exporter)